### PR TITLE
Rename Fuze to CT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO15VENDOREXPERIMENT=1
 PACKAGES = $(shell go list ./ct)
 
 build:
-	@go install -v github.com/coreos/terraform-provider-fuze
+	@go install -v github.com/coreos/terraform-provider-ct
 
 test:
 	go vet $(PACKAGES)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 
-	"github.com/coreos/terraform-provider-fuze/ct"
+	"github.com/coreos/terraform-provider-ct/ct"
 )
 
 func main() {


### PR DESCRIPTION
Fuze has been renames, and so has this provider. Just finishing the rename here.