### PR TITLE
ct: Add platform field to config resource type

### DIFF
--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -20,6 +20,12 @@ func dataSourceCTConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"platform": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				ForceNew: true,
+			},
 			"pretty_print": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -46,15 +52,18 @@ func dataSourceCTConfigRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func renderCTConfig(d *schema.ResourceData) (string, error) {
-	pretty := d.Get("pretty_print").(bool)
 	config := d.Get("content").(string)
+	platform := d.Get("platform").(string)
+	pretty := d.Get("pretty_print").(bool)
 
+	// parse bytes int a Container Linux Config
 	cfg, rpt := ct.Parse([]byte(config))
 	if rpt.IsFatal() {
 		return "", errors.New(rpt.String())
 	}
 
-	ignition, rpt := ct.ConvertAs2_0(cfg, "")
+	// convert Container Linux Config to an Ignition Config
+	ignition, rpt := ct.ConvertAs2_0(cfg, platform)
 	if rpt.IsFatal() {
 		return "", errors.New(rpt.String())
 	}

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -68,6 +68,46 @@ const prettyExpected = `{
   "passwd": {}
 }`
 
+const ec2Resource = `
+data "ct_config" "ec2" {
+  pretty_print = true
+	platform = "ec2"
+  content  = <<EOT
+---
+etcd:
+  advertise_client_urls:       http://{PUBLIC_IPV4}:2379
+  initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
+  listen_client_urls:          http://0.0.0.0:2379
+  listen_peer_urls:            http://{PRIVATE_IPV4}:2380
+  discovery:                   https://discovery.etcd.io/<token>
+EOT
+}
+`
+
+const ec2Expected = `{
+  "ignition": {
+    "version": "2.0.0",
+    "config": {}
+  },
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "name": "etcd-member.service",
+        "enable": true,
+        "dropins": [
+          {
+            "name": "20-clct-etcd-member.conf",
+            "contents": "[Unit]\nRequires=coreos-metadata.service\nAfter=coreos-metadata.service\n\n[Service]\nEnvironmentFile=/run/metadata/coreos\nExecStart=\nExecStart=/usr/lib/coreos/etcd-wrapper $ETCD_OPTS \\\n  --listen-peer-urls=\"http://${COREOS_EC2_IPV4_LOCAL}:2380\" \\\n  --listen-client-urls=\"http://0.0.0.0:2379\" \\\n  --initial-advertise-peer-urls=\"http://${COREOS_EC2_IPV4_LOCAL}:2380\" \\\n  --advertise-client-urls=\"http://${COREOS_EC2_IPV4_PUBLIC}:2379\" \\\n  --discovery=\"https://discovery.etcd.io/\u003ctoken\u003e\""
+          }
+        ]
+      }
+    ]
+  },
+  "networkd": {},
+  "passwd": {}
+}`
+
 func TestRender(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -76,6 +116,12 @@ func TestRender(t *testing.T) {
 				Config: prettyResource,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.example", "rendered", prettyExpected),
+				),
+			},
+			r.TestStep{
+				Config: ec2Resource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.ec2", "rendered", ec2Expected),
 				),
 			},
 		},


### PR DESCRIPTION
* Add a platform field to the ct_config resource to enable platform-specific templating. Details on platform-specific templating can be found in https://github.com/coreos/container-linux-config-transpiler/blob/master/config/templating/templating.go#L27
* Platform defaults to "", which performs no platform-specific templating (i.e. bare-metal or other platforms)

```
# input
data "ct_config" "controller" {
  pretty_print = false
  provider     = "gce"
  content      = "${file("controller.yaml")}"
}

# usage of output
resource "google_compute_instance_template" "controller" {
  machine_type = "${var.machine_type}"

  metadata {
    user-data = "${data.ct_config.controller.rendered}"
  }
  ...
```

Fixes https://github.com/coreos/bugs/issues/2049
cc @bloo