### PR TITLE
*: Prepare for v0.2.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+bin/
+_output/
 *.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: go
 go:
   - 1.8
 script:
+  - make
   - make test
-  - make build

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,14 @@
+# terraform-provider-ct
+
+Notable changes between releases.
+
+## v0.2.0 (2017-08-03)
+
+* Add `platform` field to the `ct_config` data source
+* Add support for platform [dynamic templating](https://coreos.com/os/docs/latest/dynamic-data.html)
+* Update to support Terraform v0.9.2+
+* Update Container Linux `ct` to v0.3.1
+
+## v0.1.0 (2016-11-11)
+
+Initial release as `tf-provider-fuze`.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,47 @@
-.PHONY: test build vendor
+export CGO_ENABLED:=0
 
+VERSION=$(shell ./scripts/git-version)
 PACKAGES = $(shell go list ./ct)
 
-build:
-	@go install -v github.com/coreos/terraform-provider-ct
+.PHONY: all
+all: bin/terraform-provider-ct
 
+bin/terraform-provider-ct:
+	@go build -o $@ -v github.com/coreos/terraform-provider-ct
+
+.PHONY: install
+install: bin/terraform-provider-ct
+	@cp $< $(GOPATH_BIN)
+
+.PHONY: test
 test:
 	go vet $(PACKAGES)
 	go test -v $(PACKAGES)
 
+.PHONY: vendor
 vendor:
 	@glide update --strip-vendor
 	@glide-vc --use-lock-file --no-tests --only-code
+
+.PHONY: clean
+clean:
+	@rm -rf bin
+	@rm -rf _output
+
+.PHONY: release
+release: \
+	clean \
+	_output/plugin-linux-amd64.tar.gz \
+	_output/plugin-darwin-amd64.tar.gz
+
+_output/plugin-%.tar.gz: NAME=terraform-provider-ct-$(VERSION)-$*
+_output/plugin-%.tar.gz: DEST=_output/$(NAME)
+_output/plugin-%.tar.gz: _output/%/terraform-provider-ct
+	@mkdir -p $(DEST)
+	@cp _output/$*/terraform-provider-ct $(DEST)
+	@tar zcvf $(DEST).tar.gz -C _output $(NAME)
+
+_output/linux-amd64/terraform-provider-ct: GOARGS = GOOS=linux GOARCH=amd64
+_output/darwin-amd64/terraform-provider-ct: GOARGS = GOOS=darwin GOARCH=amd64
+_output/%/terraform-provider-ct:
+	$(GOARGS) go build -o $@ github.com/coreos/terraform-provider-ct

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Terraform resources, e.g. as user-data for cloud instances.
   [1]: https://github.com/coreos/ignition "Ignition"
   [2]: https://github.com/coreos/container-linux-config-transpiler "CT"
 
+## Requirements
+
+* Terraform 0.9.x
 
 ## Installation
 
@@ -20,7 +23,6 @@ providers {
   ct = "/$GOPATH/bin/terraform-provider-ct"
 }
 ```
-
 
 ## Example Usage
 
@@ -35,29 +37,24 @@ resource "aws_instance" "web" {
 }
 ```
 
-## Build
+## Development
 
-```
+To develop the provider plugin locally, you'll need [Go](http://www.golang.org/) 1.8+ installed and a [GOPATH](http://golang.org/doc/code.html#GOPATH) setup. Build the plugin locally.
+
+```sh
 make
 ```
 
-### Dependencies
+Optionally, install the plugin to `$(GOPATH)/bin`.
 
-### Adding Dependencies
-
-After adding a new `import` to the source, use `glide get` to add the dependency to the `glide.yaml` and `glide.lock` files.
-
-```
-glide get github.com/$ORG/$PROJ
+```sh
+make install
 ```
 
-### Updating Dependencies
+### Vendor
 
-To update an existing package, edit the `glide.yaml` file to the desired verison (most likely a semver tag or git hash), and run `make revendor`.
+Add or update dependencies in glide.yaml and vendor. The [glide](https://github.com/Masterminds/glide) and [glide-vc](https://github.com/sgotti/glide-vc) tools vendor and prune dependencies.
 
+```sh
+make vendor
 ```
-{{ edit the entry in glide.yaml }}
-make revendor
-```
-
-If the update was successful, `glide.lock` will have been updated to reflect the changes to `glide.yaml` and the package will have been updated in `vendor`.

--- a/scripts/git-version
+++ b/scripts/git-version
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# parse the current git commit hash
+COMMIT=`git rev-parse HEAD`
+
+# check if the current commit has a matching tag
+TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
+
+# use the matching tag as the version, if available
+if [ -z "$TAG" ]; then
+    VERSION=$COMMIT
+else
+    VERSION=$TAG
+fi
+
+# check for changed files (not untracked files)
+if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+    VERSION="${VERSION}-dirty"
+fi
+
+echo $VERSION
+


### PR DESCRIPTION
* Structure README and requirements following upstream Terraform providers
* Add a release target which builds statically linked plugins and tarballs

*Note:* This will be the last release with the name "terraform-provider-ct". See #7 and #12 