### PR TITLE
Add ability to append Container Linux snippets

### DIFF
--- a/ct/datasource_ct_config.go
+++ b/ct/datasource_ct_config.go
@@ -2,13 +2,15 @@ package ct
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 
 	ct "github.com/coreos/container-linux-config-transpiler/config"
+	ignition "github.com/coreos/ignition/config/v2_1"
+	ignitionTypesV2_1 "github.com/coreos/ignition/config/v2_1/types"
 )
 
 func dataSourceCTConfig() *schema.Resource {
@@ -24,6 +26,14 @@ func dataSourceCTConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "",
+				ForceNew: true,
+			},
+			"snippets": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
 				ForceNew: true,
 			},
 			"pretty_print": &schema.Schema{
@@ -52,27 +62,50 @@ func dataSourceCTConfigRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func renderCTConfig(d *schema.ResourceData) (string, error) {
-	config := d.Get("content").(string)
+	// unchecked assertions seem to be the norm in Terraform :S
+	content := d.Get("content").(string)
 	platform := d.Get("platform").(string)
+	snippetsIface := d.Get("snippets").([]interface{})
 	pretty := d.Get("pretty_print").(bool)
 
-	// parse bytes int a Container Linux Config
-	cfg, ast, rpt := ct.Parse([]byte(config))
-	if rpt.IsFatal() {
-		return "", errors.New(rpt.String())
+	snippets := make([]string, len(snippetsIface))
+	for i := range snippetsIface {
+		snippets[i] = snippetsIface[i].(string)
 	}
 
-	// convert Container Linux Config to an Ignition Config
-	ignition, rpt := ct.Convert(cfg, platform, ast)
-	if rpt.IsFatal() {
-		return "", errors.New(rpt.String())
+	ign, err := clcToIgnition([]byte(content), platform)
+	if err != nil {
+		return "", err
+	}
+
+	for _, content := range snippets {
+		ignext, err := clcToIgnition([]byte(content), platform)
+		if err != nil {
+			return "", err
+		}
+		ign = ignition.Append(ign, ignext)
 	}
 
 	if pretty {
-		ignitionJSON, err := json.MarshalIndent(&ignition, "", "  ")
+		ignitionJSON, err := json.MarshalIndent(ign, "", "  ")
 		return string(ignitionJSON), err
 	}
 
-	ignitionJSON, err := json.Marshal(&ignition)
+	ignitionJSON, err := json.Marshal(ign)
 	return string(ignitionJSON), err
+}
+
+// Parse Container Linux config and convert to Ignition v2.1.0 format.
+func clcToIgnition(data []byte, platform string) (ignitionTypesV2_1.Config, error) {
+	// parse bytes into a Container Linux Config
+	clc, ast, report := ct.Parse([]byte(data))
+	if report.IsFatal() {
+		return ignitionTypesV2_1.Config{}, fmt.Errorf("error parsing Container Linux Config: %v", report.String())
+	}
+	// convert Container Linux Config to an Ignition Config
+	ign, report := ct.Convert(clc, platform, ast)
+	if report.IsFatal() {
+		return ignitionTypesV2_1.Config{}, fmt.Errorf("error converting to Ignition: %v", report.String())
+	}
+	return ign, nil
 }

--- a/ct/datasource_ct_config_test.go
+++ b/ct/datasource_ct_config_test.go
@@ -131,6 +131,58 @@ const ec2Expected = `{
   }
 }`
 
+const snippetsResource = `
+data "ct_config" "combine" {
+	pretty_print = true
+	content = <<EOT
+---
+storage:
+  filesystems:
+    - name: "rootfs"
+      mount:
+        device: "/dev/disk/by-label/ROOT"
+        format: "ext4"
+EOT
+	snippets = [
+<<EOT
+---
+systemd:
+  units:
+    - name: docker.service
+      enable: true
+EOT
+	]
+}
+`
+const snippetsExpected = `{
+  "ignition": {
+    "config": {},
+    "timeouts": {},
+    "version": "2.1.0"
+  },
+  "networkd": {},
+  "passwd": {},
+  "storage": {
+    "filesystems": [
+      {
+        "mount": {
+          "device": "/dev/disk/by-label/ROOT",
+          "format": "ext4"
+        },
+        "name": "rootfs"
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "enable": true,
+        "name": "docker.service"
+      }
+    ]
+  }
+}`
+
 func TestRender(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -145,6 +197,12 @@ func TestRender(t *testing.T) {
 				Config: ec2Resource,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.ct_config.ec2", "rendered", ec2Expected),
+				),
+			},
+			r.TestStep{
+				Config: snippetsResource,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.ct_config.combine", "rendered", snippetsExpected),
 				),
 			},
 		},

--- a/glide.lock
+++ b/glide.lock
@@ -71,6 +71,7 @@ imports:
   - config/v2_1
   - config/v2_1/types
   - config/validate
+  - config/validate/astjson
   - config/validate/astnode
   - config/validate/report
 - name: github.com/davecgh/go-spew
@@ -147,4 +148,8 @@ imports:
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/vincent-petithory/dataurl
   version: 9a301d65acbb728fcc3ace14f45f511a4cfeea9c
+- name: go4.org
+  version: 03efcb870d84809319ea509714dd6d19a1498483
+  subpackages:
+  - errorutil
 testImports: []

--- a/vendor/github.com/coreos/ignition/config/validate/astjson/node.go
+++ b/vendor/github.com/coreos/ignition/config/validate/astjson/node.go
@@ -1,0 +1,73 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package astjson
+
+import (
+	"io"
+
+	json "github.com/ajeddeloh/go-json"
+	"github.com/coreos/ignition/config/validate/astnode"
+	"go4.org/errorutil"
+)
+
+type JsonNode json.Node
+
+func FromJsonRoot(n json.Node) JsonNode {
+	return JsonNode(n)
+}
+
+func (n JsonNode) ValueLineCol(source io.ReadSeeker) (int, int, string) {
+	return posFromOffset(n.End, source)
+}
+
+func (n JsonNode) KeyLineCol(source io.ReadSeeker) (int, int, string) {
+	return posFromOffset(n.KeyEnd, source)
+}
+
+func (n JsonNode) LiteralValue() interface{} {
+	return n.Value
+}
+
+func (n JsonNode) SliceChild(index int) (astnode.AstNode, bool) {
+	if slice, ok := n.Value.([]json.Node); ok {
+		return JsonNode(slice[index]), true
+	}
+	return JsonNode{}, false
+}
+
+func (n JsonNode) KeyValueMap() (map[string]astnode.AstNode, bool) {
+	if kvmap, ok := n.Value.(map[string]json.Node); ok {
+		newKvmap := map[string]astnode.AstNode{}
+		for k, v := range kvmap {
+			newKvmap[k] = JsonNode(v)
+		}
+		return newKvmap, true
+	}
+	return nil, false
+}
+
+func (n JsonNode) Tag() string {
+	return "json"
+}
+
+// wrapper for errorutil that handles missing sources sanely and resets the reader afterwards
+func posFromOffset(offset int, source io.ReadSeeker) (int, int, string) {
+	if source == nil {
+		return 0, 0, ""
+	}
+	line, col, highlight := errorutil.HighlightBytePosition(source, int64(offset))
+	source.Seek(0, 0) // Reset the reader to the start so the next call isn't relative to this position
+	return line, col, highlight
+}

--- a/vendor/go4.org/LICENSE
+++ b/vendor/go4.org/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/go4.org/errorutil/highlight.go
+++ b/vendor/go4.org/errorutil/highlight.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errorutil helps make better error messages.
+package errorutil // import "go4.org/errorutil"
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// HighlightBytePosition takes a reader and the location in bytes of a parse
+// error (for instance, from json.SyntaxError.Offset) and returns the line, column,
+// and pretty-printed context around the error with an arrow indicating the exact
+// position of the syntax error.
+func HighlightBytePosition(f io.Reader, pos int64) (line, col int, highlight string) {
+	line = 1
+	br := bufio.NewReader(f)
+	lastLine := ""
+	thisLine := new(bytes.Buffer)
+	for n := int64(0); n < pos; n++ {
+		b, err := br.ReadByte()
+		if err != nil {
+			break
+		}
+		if b == '\n' {
+			lastLine = thisLine.String()
+			thisLine.Reset()
+			line++
+			col = 1
+		} else {
+			col++
+			thisLine.WriteByte(b)
+		}
+	}
+	if line > 1 {
+		highlight += fmt.Sprintf("%5d: %s\n", line-1, lastLine)
+	}
+	highlight += fmt.Sprintf("%5d: %s\n", line, thisLine.String())
+	highlight += fmt.Sprintf("%s^\n", strings.Repeat(" ", col+5))
+	return
+}


### PR DESCRIPTION
Allow users to supply a list of Container Linux Configs that should be appended. This means base
configs can be additively extended with custom snippets of Container Linux configs. This is a long-awaited feature to unlock end-user customizations.

### Testing

I'm putting this up for comment, but still working on validating the usage in real-world scenarios.

```
data "ct_config" "worker" {
  content      = "${file("base.yaml")}"
  platform     = "ec2"
  pretty_print = false

  snippets = [
    "${file("units.yaml")}",
    "${file("storage.yaml")}",
  ]
}

resource "aws_instance" "worker" {
  user_data = "${data.ct_config.worker.rendered}"
}
```

rel: https://github.com/coreos/matchbox/issues/622