### PR TITLE
Update .travis for Go v1.11, remove v1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.8.x
   - 1.9.x
-
+  - "1.10.x"
+  - "1.11.x"
 script:
   - make
   - make test

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `snippets` field is an optional list of Container Linux Config snippets that
 
 ## Development
 
-To develop the provider plugin locally, set up [Go](http://www.golang.org/) 1.8+ and a valid [GOPATH](http://golang.org/doc/code.html#GOPATH). Build the plugin locally.
+To develop the provider plugin locally, set up [Go](http://www.golang.org/) 1.9+ and a valid [GOPATH](http://golang.org/doc/code.html#GOPATH). Build the plugin locally.
 
 ```sh
 make


### PR DESCRIPTION
Test against Go v1.9, v1.10, and v1.11