### PR TITLE
Improve instructions to use the 3rd-party plugin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,49 @@
-# Terraform Provider for Container Linux Configs
+# terraform-provider-ct
 
-The `ct` provider provides a `ct_config` data source that parses a [Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md), validates the content, and renders [Ignition](https://github.com/coreos/ignition). The rendered strings can be used as input to other Terraform resources (e.g. user-data for instances).
-
-## Ignition schema output
-
-Each minor version of `terraform-provider-ct` is tightly coupled with a minor version of the Ignition schema. Ignition transparently handles old Ignition schema versions, so this isn't normally an issue.
-
-However, it is **not safe** to upgrade between minor versions on existing managed clusters. Minor version upgrades of this plugin **will re-provision your cluster** because the Ignition config output has changed.
-
-| `terraform-provider-ct` | Ignition schema version |
-| ----------------------- | ----------------------- |
-| 0.2.x                   | 2.0                     |
-| 0.3.x                   | 2.2                     |
+`terraform-provider-ct` allows defining a `ct_config` [Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) resource to validate the content and render an [Ignition](https://github.com/coreos/ignition) document. Rendered Ignition may be used as input to other Terraform resources (e.g. instance user-data).
 
 ## Requirements
 
-* Terraform 0.9.x
+* Terraform v0.11+ [installed](https://www.terraform.io/downloads.html)
 
-## Installation
+## Install
 
-Add the `terraform-provider-ct` plugin binary on your filesystem.
+Add the `terraform-provider-ct` plugin binary for your system to the Terraform 3rd-party [plugin directory](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) `~/.terraform.d/plugins`.
+
+```sh
+VERSION=v0.3.0
+wget https://github.com/coreos/terraform-provider-ct/releases/download/$VERSION/terraform-provider-ct-$VERSION-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-$VERSION-linux-amd64.tar.gz
+mv terraform-provider-ct-$VERSION-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_$VERSION
+```
+
+Terraform plugin binary names are versioned to allow for migrations of managed infrastructure.
 
 ```
-# dev
-go get -u github.com/coreos/terraform-provider-ct
-```
-
-Register the plugin in `~/.terraformrc`.
-
-```hcl
-providers {
-  ct = "/$GOPATH/bin/terraform-provider-ct"
-}
+$ tree ~/.terraform.d/
+/home/user/.terraform.d/
+└── plugins
+    ├── terraform-provider-ct_v0.2.1
+    └── terraform-provider-ct_v0.3.0
 ```
 
 ## Usage
+
+Configure the ct provider in a `providers.tf` file.
+
+```hcl
+provider "ct" {
+  version = "0.3.0"
+}
+```
+
+Run `terraform init` to ensure plugin version requirements are met.
+
+```
+$ terraform init
+```
+
+Declare a `ct_config` resource in Terraform.
 
 ```hcl
 data "ct_config" "worker" {
@@ -53,9 +62,18 @@ resource "aws_instance" "worker" {
 }
 ```
 
-The optional platform can be "azure", "ec2", "gce", or [others](https://github.com/coreos/container-linux-config-transpiler/blob/master/config/platform/platform.go) to perform platform-specific susbstitutions. By default, platform is "" (none, for bare-metal). 
+Set the `content` to the contents of a Container Linux Config that should be validated and rendered as Ignition. Optionally, use the `snippets` field to append a list of Container Linux Config snippets. Use `platform` if [platform-specific](https://github.com/coreos/container-linux-config-transpiler/blob/master/config/platform/platform.go) susbstitution is desired.
 
-The `snippets` field is an optional list of Container Linux Config snippets that are appended to the main config specified in `content` before being rendered into an Ignition config.
+### Ignition schema output
+
+Each minor version of `terraform-provider-ct` is tightly coupled with a minor version of the Ignition schema. Ignition transparently handles old Ignition schema versions, so this isn't normally an issue.
+
+Upgrading between versions for existing managed clusters **may not be safe**. Check your usage to determine whether a `user_data` change to an instance would re-provision a machine (important machines may  be configured to ignore `user_data` changes).
+
+| terraform-provider-ct | Ignition schema version |
+|-----------------------|-------------------------|
+| 0.2.x                 | 2.0                     |
+| 0.3.x                 | 2.2                     |
 
 ## Development
 
@@ -63,14 +81,8 @@ The `snippets` field is an optional list of Container Linux Config snippets that
 
 To develop the provider plugin locally, build an executable with Go v1.11+.
 
-```sh
-make
 ```
-
-Optionally, install the plugin to `$(GOPATH)/bin`.
-
-```sh
-make install
+make
 ```
 
 ### Vendor


### PR DESCRIPTION
* Refresh the requirements, install, and usage documentation
* Use Terraform's 3rd-party plugin directory to provide a mechinism
for migrating infrastructure between plugin versions
* https://www.terraform.io/docs/configuration/providers.html#third-party-plugins

Note: List Terraform v0.11 as a requirement. While nothing has been done to
break functionality with old Terraform versions, they're quite old. Going
forward, v0.11+ will be assumed